### PR TITLE
Replace image logos with text

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,10 @@
 <div class='header'>
   <div class="container">
     <div class="logo">
-      <a href="{{ '/' | relative_url }}"><img width="{{ site.logo.desktop_width }}" height="{{ site.logo.desktop_height }}" alt="{{ site.title }}" src="{{ site.logo.desktop | relative_url }}" /></a>
+      <a href="{{ '/' | relative_url }}">Merced Botanical Garden</a>
     </div>
     <div class="logo-mobile">
-      <a href="{{ '/' | relative_url }}"><img width="{{ site.logo.mobile_width }}" height="{{ site.logo.mobile_height }}" alt="{{ site.title }}" src="{{ site.logo.mobile | relative_url }}" /></a>
+      <a href="{{ '/' | relative_url }}">MBG</a>
     </div>
     {% include main-menu.html %}
     {% include hamburger.html %}

--- a/_sass/components/_logo.scss
+++ b/_sass/components/_logo.scss
@@ -3,29 +3,26 @@
   @include media-breakpoint-up(sm) {
     display: block;
   }
-  img {
-    max-width: unset;
-  }
+  font-weight: bold;
+  font-size: 1.5rem;
   a {
+    text-decoration: none;
+    color: inherit;
     display: block;
-    width: 100%;
-    height: 100%;
   }
 }
+
 .logo-mobile {
   display: block;
-  width: 40px;
-  padding: 10px 0 10px 0;
+  padding: 10px 0;
   @include media-breakpoint-up(sm) {
     display: none;
   }
-  img {
-    width: 100%;
-    height: auto;
-  }
+  font-weight: bold;
+  font-size: 1.25rem;
   a {
+    text-decoration: none;
+    color: inherit;
     display: block;
-    width: 100%;
-    height: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- replace desktop and mobile logo images with text
- update the logo styles for text logos

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6877db0d67f48321962de0e2d45ffbbc