### PR TITLE
Add site-wide pre-operational notice with board inquiry link

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -1,2 +1,3 @@
 email: 'info@mercedgardens.org'
 phone: '(408) 784-9555'
+board_email: 'tsainez@gmail.com'

--- a/_includes/announcement.html
+++ b/_includes/announcement.html
@@ -1,0 +1,9 @@
+<div class="announcement-banner" role="region" aria-label="Pre-operational status announcement">
+  <div class="container">
+    <p class="announcement-banner-text">
+      🌱 <strong>We are pre-operational</strong> — everything you see here is a work in progress.
+      Interested in joining our volunteer board?
+      <a href="mailto:{{ site.data.contact.board_email }}?subject=Board%20Inquiry%20-%20Merced%20Botanical%20Gardens">Email us</a>
+    </p>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,6 +39,7 @@
   <a class="visually-hidden-focusable position-absolute top-0 start-0 p-3 bg-white skip-to-content" href="#main-content">Skip to content</a>
   {% include main-menu-mobile.html %}
   <div id="wrapper" class="wrapper">
+    {% include announcement.html %}
     {% include header.html headerClass='header-extra' %}
     <main id="main-content">
       {{content}}

--- a/_sass/components/_announcement.scss
+++ b/_sass/components/_announcement.scss
@@ -1,0 +1,23 @@
+.announcement-banner {
+  background-color: $primary-dark;
+  color: $white;
+  text-align: center;
+  padding: 12px 0;
+
+  .announcement-banner-text {
+    margin: 0;
+    font-size: 15px;
+    line-height: 1.4;
+  }
+
+  a {
+    color: $white;
+    text-decoration: underline;
+    font-weight: 700;
+
+    &:hover,
+    &:focus {
+      color: $white-offset;
+    }
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -84,6 +84,7 @@ $sub-footer-text-color: $white;
 // Components
 @import "components/type";
 @import "components/page";
+@import "components/announcement";
 @import "components/header";
 @import "components/footer";
 @import "components/sub-footer";

--- a/get-involved.html
+++ b/get-involved.html
@@ -5,6 +5,13 @@ title: Get Involved
 
 <div class="get-involved-content">
   <section class="mb-5">
+    <h2>Join Our Board</h2>
+    <p>Merced Botanical Gardens is pre-operational — we are building our founding board right now, and everything about the organization is a work in progress. This is a chance to shape a community institution from its very first days.</p>
+    <p><strong>Please note:</strong> because we are such an early-stage organization, all board positions are strictly volunteer and unpaid.</p>
+    <a href="mailto:tsainez@gmail.com?subject=Board%20Inquiry%20-%20Merced%20Botanical%20Gardens" class="button">Email Us About Joining the Board</a>
+  </section>
+
+  <section class="mb-5">
     <h2>Volunteer</h2>
     <p>We are always looking for enthusiastic volunteers to help us maintain the gardens and organize events. If you love nature and want to give back to the community, join us!</p>
     <p>We will share upcoming volunteer opportunities soon—stay tuned!</p>

--- a/index.md
+++ b/index.md
@@ -15,3 +15,5 @@ show_call_box: false
 Merced deserves a world-class botanical garden.
 
 A space that celebrates the Central Valley's agricultural heritage while providing education, conservation, and community gathering opportunities.
+
+**We're just getting started.** Merced Botanical Gardens is pre-operational, and everything you see here is a work in progress. If you'd like to help build it from the ground up, [email us about joining our volunteer board](mailto:tsainez@gmail.com?subject=Board%20Inquiry%20-%20Merced%20Botanical%20Gardens).


### PR DESCRIPTION
## Summary

Makes the project's pre-operational status front and center across the whole site, and gives visitors a direct way to inquire about joining the board.

- **Site-wide announcement banner** (`_includes/announcement.html`, rendered at the top of every page via `_layouts/default.html`): "We are pre-operational — everything you see here is a work in progress," with an **Email us** mailto link (`tsainez@gmail.com`, pre-filled subject "Board Inquiry - Merced Botanical Gardens") for volunteer board inquiries. Styled in the site's green palette via a new `_sass/components/_announcement.scss` component.
- **Homepage intro** (`index.md`): adds a "We're just getting started" paragraph stating the pre-operational/work-in-progress status with the same board-inquiry mailto link.
- **Get Involved page** (`get-involved.html`): new "Join Our Board" section at the top, explicitly noting that **all board positions are strictly volunteer and unpaid** given the early stage of the organization, with an "Email Us About Joining the Board" button.
- **Contact data** (`_data/contact.yml`): adds `board_email` so the banner's address is maintained in one place.

## Testing

- `bundle exec jekyll build` succeeds (only pre-existing Sass deprecation warnings from the vendored hamburgers library).
- Verified in the built `_site/` output that the banner renders on every page and the mailto links appear on the homepage, Get Involved, and About pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaF6w5wqS48BtRMuEnM5na

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaF6w5wqS48BtRMuEnM5na)_